### PR TITLE
feat: optional vinyl brake behaviour (fixes #1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Optional vinyl brake / soft start behaviour for the PLAY button when Vinyl Mode is active
+- Config flag `PLAY_BRAKE_ON_VINYL` to enable or disable this behaviour
+
+### Documentation
+
+- Documented optional vinyl brake behaviour in the README
+
 ## v1.0
 
 Initial public GitHub release of the custom Pioneer DDJ-FLX4 mapping.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,0 +1,210 @@
+# Pioneer DDJ-FLX4 Custom Mapping — Configuration
+
+This file documents script configuration options available in the mapping.
+
+These values can be changed directly in the mapping script.
+
+---
+
+# Browser
+
+## BROWSE_FOCUS_TOGGLE_ONLY
+
+Toggle between simple focus switching and full Mixxx focus cycling.
+
+true  
+Browse press toggles only between:
+
+• library tree  
+• track table
+
+false  
+Use Mixxx default focus cycling.
+
+---
+
+## BROWSE_LONGPRESS_MS
+
+Reserved for possible long-press browser behavior.
+
+Currently unused.
+
+Default: 300
+
+---
+
+# Sampler
+
+## SAMPLER_LONGPRESS_MS
+
+Time threshold for detecting sampler long press.
+
+Default: 350 ms
+
+---
+
+# Quantize / Keylock
+
+## QUANTIZE_LONGPRESS_MS
+
+Long press threshold for mixer cue buttons.
+
+Short press → quantize  
+Long press → keylock
+
+Default: 350 ms
+
+---
+
+# Looping
+
+## LOOP_ADJUST_MODE
+
+Controls loop adjust workflow.
+
+Options:
+
+simple  
+Standard Mixxx loop adjustment
+
+hercules  
+Hercules-style loop workflow with jog-based loop edge editing
+
+Default: simple
+
+---
+
+## loopAdjustStepBeats
+
+Step size used for loop edge adjustment.
+
+Default: 0.02
+
+---
+
+## loopAdjustTimeoutMs
+
+Time until loop adjust mode exits automatically.
+
+Default: 5000
+
+---
+
+## reloopExitBeats
+
+Default loop size created by 4BEAT/EXIT if no loop exists.
+
+Default: 4
+
+---
+
+# Navigation
+
+## quickJumpSize
+
+Beat jump size used for quick jump commands.
+
+Default: 32
+
+---
+
+# Jog behavior
+
+## fastSeekScale
+
+Multiplier used for Shift + jog search.
+
+Default: 150
+
+---
+
+## bendScale
+
+Pitch bend sensitivity.
+
+Default: 0.8
+
+---
+
+## loopAdjustMultiply
+
+Legacy multiplier for simple loop adjust mode.
+
+Default: 50
+
+---
+
+## jogPPR
+
+Jog pulses per revolution.
+
+Default: 720
+
+---
+
+## jogRPM
+
+Virtual platter speed.
+
+Default: 33⅓
+
+---
+
+## scratchScale
+
+Scratch movement scaling.
+
+Default: 1.0
+
+---
+
+## seekScratchMultiplier
+
+Speed multiplier for seek scratch mode.
+
+Default: 4.0
+
+---
+
+# STEMS
+
+## STEMS_PAD5_8_MODE
+
+Controls behavior of pads 5-8 in STEMS mode.
+
+Options:
+
+solo  
+Momentary solo / hold-mute behavior
+
+fx  
+Pads control stem quick effects
+
+Default: solo
+
+---
+
+# Optional Vinyl Brake
+
+## PLAY_BRAKE_ON_VINYL
+
+Enables optional vinyl start/stop behavior for Play button.
+
+false  
+Play behaves normally
+
+true  
+Play triggers vinyl brake / soft start when Vinyl mode is active
+
+Default: false
+
+---
+
+## Vinyl FX parameters
+vinylFx = {
+brakeFactor: 10,
+softStartFactor: 15
+}
+
+
+Control strength of brake and soft start.

--- a/CONTROLS.md
+++ b/CONTROLS.md
@@ -1,0 +1,409 @@
+# Pioneer DDJ-FLX4 Custom Mapping — Controls
+
+This document describes the **user-visible controller behavior** of the custom Mixxx mapping.
+
+The JavaScript mapping script is the authoritative source of truth.
+
+If XML descriptions differ from the script, the script behavior takes precedence.
+
+---
+
+# Browser / Library
+
+## Browse encoder
+
+Rotate  
+• Scroll library vertically
+
+Shift + rotate  
+• Zoom waveform on both decks
+
+Press  
+• Toggle focus between library tree and track table
+
+Shift + press  
+• Currently unused
+
+---
+
+## Load buttons
+
+Load  
+• Load selected track into the deck
+
+Double press  
+• Instant double (clone track from the opposite deck)
+
+Shift + Load (Deck 1)  
+• Toggle maximize / minimize library
+
+Shift + Load (Deck 2)  
+• Expand folder / MoveRight in library tree
+
+---
+
+# Transport
+
+## Play / Pause
+
+Default  
+• Standard Mixxx play / pause
+
+Shift + Play  
+• Reverse roll (censor)
+
+Optional behavior exists where Play acts like a vinyl start/stop when Vinyl mode is active.
+
+---
+
+## Cue
+
+Cue  
+• Standard cue_default
+
+Shift + Cue  
+• Jump to track start (start_stop)
+
+---
+
+# Sync
+
+Short press  
+• One-shot beat sync
+
+Long press  
+• Toggle sync lock
+
+Shift + Sync  
+• Cycle tempo range
+
+Tempo ranges cycle:
+
+• ±8%  
+• ±16%  
+• ±32%  
+• ±64%  
+• ±100%
+
+---
+
+# Jog Wheels
+
+## Platter rotate
+
+Vinyl mode ON  
+• Scratch
+
+Vinyl mode OFF  
+• Pitch bend
+
+Side ring  
+• Pitch bend
+
+Shift + rotate  
+• Fast search
+
+---
+
+## Platter touch
+
+Touch behavior is script controlled.
+
+Touching the platter:
+
+• Deck stopped → scratch  
+• Vinyl mode active → scratch  
+• Otherwise → pitch bend
+
+Releasing the platter disables scratch.
+
+---
+
+## Shift + platter touch
+
+Activates **seek scratch mode**.
+
+Jog rotation behaves like fast track seeking.
+
+---
+
+# Vinyl Mode
+
+Vinyl mode is toggled per deck with:
+
+Shift + 4BEAT / EXIT
+
+When enabled:
+
+• jog touch enables scratching while playing  
+• jog rotation behaves like a vinyl platter
+
+---
+
+# Tempo Fader
+
+High-resolution 14-bit tempo control.
+
+---
+
+# Loop Section
+
+## Loop In
+
+Sets loop in point.
+
+Pending loop-out state is indicated via LED behavior.
+
+---
+
+## Loop Out
+
+Sets loop out point and activates loop.
+
+---
+
+## 4BEAT / EXIT
+
+If loop active  
+• exit loop
+
+If loop inactive  
+• reloop previous loop if available  
+• otherwise create default loop
+
+---
+
+## Shift + 4BEAT / EXIT
+
+Toggle Vinyl mode.
+
+---
+
+## Cue / Loop Call
+
+Left  
+• halve active loop
+
+Right  
+• double active loop
+
+Shift + Left  
+• quick jump backward
+
+Shift + Right  
+• quick jump forward
+
+---
+
+# Mixer
+
+## Channel faders
+Standard deck volume control.
+
+## Crossfader
+Standard Mixxx crossfader.
+
+## Trim
+Pregain control.
+
+## EQ
+
+Three band EQ:
+
+• High  
+• Mid  
+• Low
+
+---
+
+## Headphone Cue
+
+Toggle deck PFL.
+
+---
+
+# Quantize / Keylock
+
+Mixer cue buttons use custom behavior:
+
+Short press  
+• toggle quantize
+
+Long press  
+• toggle keylock
+
+---
+
+# Smart CFX
+
+Smart CFX button:
+
+Press  
+• Toggle QuickEffectRack
+
+Shift + press  
+• Cycle QuickEffect preset
+
+---
+
+# Beat FX
+
+## Channel selectors
+
+CH1 → Deck 1 FX  
+CH2 → Deck 2 FX
+
+Both selected → both decks.
+
+---
+
+## Beat Left / Right
+
+Cycle effect chain preset.
+
+---
+
+## Level / Depth knob
+
+Normal  
+• Control effect parameter (super1)
+
+Shift  
+• Control effect mix
+
+---
+
+## Beat FX On / Off
+
+Press  
+• Toggle all FX slots
+
+Shift + press  
+• Turn FX off
+
+---
+
+# Pad Modes
+
+Pad mode buttons select:
+
+• Hot Cue  
+• Keyboard (STEMS)  
+• Pad FX1  
+• Pad FX2  
+• Beat Jump  
+• Beat Loop  
+• Sampler  
+• Key Shift
+
+---
+
+# Hot Cue Mode
+
+Pads 1-8  
+• Trigger / set hot cues
+
+Shift + pads  
+• Clear hot cues
+
+---
+
+# Keyboard Mode (STEMS)
+
+Pads 1-4  
+• Toggle stem mute
+
+Shift + pads  
+• Solo stem
+
+Pads 5-8  
+• Stem solo / momentary mute depending on configuration
+
+---
+
+# Pad FX Modes
+
+Pad FX modes control Mixxx effect units.
+
+Pad layout:
+
+Pad1 → slot1  
+Pad2 → slot2  
+Pad3 → slot3  
+Pad4 → unit enable  
+Pad5 → route FX to own deck  
+Pad6 → route FX to opposite deck  
+Pad7 → unused  
+Pad8 → toggle all slots
+
+Shift pads currently mirror normal pads.
+
+---
+
+# Beat Jump Mode
+
+Pads:
+
+1 beat back  
+1 beat forward  
+2 beat back  
+2 beat forward  
+4 beat back  
+4 beat forward  
+32 beat back  
+32 beat forward
+
+---
+
+# Beat Loop Mode
+
+Pads:
+
+¼ beat  
+½ beat  
+1 beat  
+2 beat  
+4 beat  
+8 beat  
+16 beat  
+32 beat
+
+---
+
+# Sampler Mode
+
+16 samplers are used.
+
+Short press  
+• play sample
+
+Long press  
+• stop sample
+
+Shift + pad  
+• stop or eject sample
+
+LED states:
+
+off → empty  
+solid → loaded  
+blink → playing
+
+---
+
+# Key Shift Mode
+
+Pads select fixed pitch offsets.
+
+Current mapping:
+
+Pad1 → +4  
+Pad2 → +5  
+Pad3 → +6  
+Pad4 → +7  
+Pad5 → 0  
+Pad6 → +1  
+Pad7 → +2  
+Pad8 → +3
+
+Shift layer currently unused.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,31 @@ while still taking advantage of Mixxx features.
 - Browser focus toggle
 - Quantize / Keylock shortcuts
 - Vinyl mode toggle via SHIFT + 4BEAT/EXIT
+- Optional vinyl brake / soft start behaviour on the PLAY button
+- Configurable controller behaviour for selected features
+
+## Configuration
+
+Some optional behaviours can be adjusted directly in the script.
+
+### Optional vinyl brake on PLAY
+
+The mapping can optionally apply vinyl-style transport behaviour to the normal
+PLAY button when Vinyl Mode is active.
+
+This feature is disabled by default.
+
+When enabled:
+
+- pressing PLAY on a playing deck applies a brake
+- pressing PLAY on a stopped deck starts playback with a soft start
+- pressing PLAY during an active brake cancels the brake and resumes playback
+
+To enable it, set the following option in the script:
+
+    PioneerDDJFLX4.PLAY_BRAKE_ON_VINYL = true;
+
+If disabled, the PLAY button keeps the normal Mixxx Play/Pause behaviour.
 
 ## Status
 

--- a/controllers/Pioneer-DDJ-FLX4-2.0.midi.xml
+++ b/controllers/Pioneer-DDJ-FLX4-2.0.midi.xml
@@ -129,11 +129,11 @@
       <control>
         <description>PLAY/PAUSE (DECK1) - press - Play/Pause</description>
         <group>[Channel1]</group>
-        <key>play</key>
+        <key>PioneerDDJFLX4.playPressed</key>
         <status>0x90</status>
         <midino>0x0B</midino>
         <options>
-          <Normal />
+          <Script-Binding />
         </options>
       </control>
       <control>
@@ -143,13 +143,13 @@
         <status>0x90</status>
         <midino>0x0E</midino>
         <options>
-          <Normal />
+          <Script-Binding />
         </options>
       </control>
       <control>
         <description>PLAY/PAUSE (DECK2) - press - Play/Pause</description>
         <group>[Channel2]</group>
-        <key>play</key>
+        <key>PioneerDDJFLX4.playPressed</key>
         <status>0x91</status>
         <midino>0x0B</midino>
         <options>

--- a/controllers/Pioneer-DDJ-FLX4-2.0.script.js
+++ b/controllers/Pioneer-DDJ-FLX4-2.0.script.js
@@ -845,7 +845,7 @@ PioneerDDJFLX4.loadShiftPressed = function(_channel, control, value, _status, _g
 // -----------------------------------------------------------------------------
 // USER OPTION
 // -----------------------------------------------------------------------------
-PioneerDDJFLX4.PLAY_BRAKE_ON_VINYL = true;
+PioneerDDJFLX4.PLAY_BRAKE_ON_VINYL = false;
 
 PioneerDDJFLX4.vinylFx = {
     brakeFactor: 10,

--- a/controllers/Pioneer-DDJ-FLX4-2.0.script.js
+++ b/controllers/Pioneer-DDJ-FLX4-2.0.script.js
@@ -845,8 +845,12 @@ PioneerDDJFLX4.loadShiftPressed = function(_channel, control, value, _status, _g
 // -----------------------------------------------------------------------------
 // USER OPTION
 // -----------------------------------------------------------------------------
-PioneerDDJFLX4.PLAY_BRAKE_ON_VINYL = false;
+PioneerDDJFLX4.PLAY_BRAKE_ON_VINYL = true;
 
+PioneerDDJFLX4.vinylFx = {
+    brakeFactor: 10,
+    softStartFactor: 15,
+};
 
 // -----------------------------------------------------------------------------
 // RUNTIME STATE
@@ -984,7 +988,7 @@ PioneerDDJFLX4.playPressed = function(_channel, _control, value, _status, group)
         engine.setValue(group, "play", 1);
 
         if (typeof engine.softStart === "function") {
-            engine.softStart(deck, true);
+            engine.softStart(deck, true, PioneerDDJFLX4.vinylFx.softStartFactor);
         }
 
         return;
@@ -995,7 +999,7 @@ PioneerDDJFLX4.playPressed = function(_channel, _control, value, _status, group)
     PioneerDDJFLX4._startBrakeWatch(deckIdx, group);
 
     if (typeof engine.brake === "function") {
-        engine.brake(deck, true);
+        engine.brake(deck, true, PioneerDDJFLX4.vinylFx.brakeFactor);
     } else {
         engine.setValue(group, "play", 0);
     }
@@ -2006,66 +2010,71 @@ PioneerDDJFLX4._scratchDisable = function(deckNum) {
     PioneerDDJFLX4._scratchAction[deckNum - 1] = "bend";
 };
 
-// ---------- touch handlers ----------
-PioneerDDJFLX4.jogTouch = function(channel, _control, value, _status, group) {
-    const deckIdx = PioneerDDJFLX4._deckIndexFromGroup(group);
-    const deckNum = deckIdx + 1;
+ // ---------- touch handlers ----------
+ PioneerDDJFLX4.jogTouch = function(channel, _control, value, _status, group) {
+     const deckIdx = PioneerDDJFLX4._deckIndexFromGroup(group);
+     const deckNum = deckIdx + 1;
 
-    // If we are adjusting loop points, ignore touch changes to prevent scratch toggling while editing.
-    if (PioneerDDJFLX4.loopAdjustIn[deckIdx] || PioneerDDJFLX4.loopAdjustOut[deckIdx]) {
-        return;
-    }
+     // If we are adjusting loop points, ignore touch changes to prevent scratch toggling while editing.
+     if (PioneerDDJFLX4.loopAdjustIn[deckIdx] || PioneerDDJFLX4.loopAdjustOut[deckIdx]) {
+         return;
+     }
 
-    const touching = (value !== 0);
-    PioneerDDJFLX4.wheelTouch[deckIdx] = touching;
+     const touching = (value !== 0);
+     PioneerDDJFLX4.wheelTouch[deckIdx] = touching;
 
-    if (touching) {
-        // Decide scratch vs bend based on CONTROLLER vinyl state:
-        // scratch if deck not playing OR controller is in vinyl mode.
-        const playing = engine.getValue(group, "play") === 1;
-        const wantScratch = (!playing) || !!PioneerDDJFLX4._jogVinylFromController[deckIdx];
+     if (touching) {
+         // Decide scratch vs bend based on CONTROLLER vinyl state:
+         // scratch if deck not playing OR controller is in vinyl mode.
+         const playing = engine.getValue(group, "play") === 1;
+         const wantScratch = (!playing) || !!PioneerDDJFLX4._jogVinylFromController[deckIdx];
 
-        if (wantScratch) {
-            PioneerDDJFLX4._scratchAction[deckIdx] = "scratch";
-            PioneerDDJFLX4._scratchEnable(deckNum);
-        } else {
-            PioneerDDJFLX4._scratchAction[deckIdx] = "bend";
-            // ensure scratch is off if it was on
-            if (PioneerDDJFLX4._scratchEnabled[deckIdx]) {
-                PioneerDDJFLX4._scratchDisable(deckNum);
-            }
-        }
-        return;
-    }
+         if (wantScratch) {
+             PioneerDDJFLX4._scratchAction[deckIdx] = "scratch";
+             PioneerDDJFLX4._scratchEnable(deckNum);
+         } else {
+             PioneerDDJFLX4._scratchAction[deckIdx] = "bend";
 
-    // Touch released
-    if (PioneerDDJFLX4._scratchEnabled[deckIdx]) {
-        PioneerDDJFLX4._scratchDisable(deckNum);
-    } else {
-        PioneerDDJFLX4._scratchAction[deckIdx] = "bend";
-    }
-};
+             // ensure scratch is off if it was on
+             if (PioneerDDJFLX4._scratchEnabled[deckIdx]) {
+                 PioneerDDJFLX4._scratchDisable(deckNum);
+             }
+         }
+         return;
+     }
 
-    // same loop-adjust guard
-    if (PioneerDDJFLX4.loopAdjustIn[deckIdx] || PioneerDDJFLX4.loopAdjustOut[deckIdx]) {
-        return;
-    }
+     // Touch released
+     if (PioneerDDJFLX4._scratchEnabled[deckIdx]) {
+         PioneerDDJFLX4._scratchDisable(deckNum);
+     } else {
+         PioneerDDJFLX4._scratchAction[deckIdx] = "bend";
+     }
+ };
 
-    const touching = (value !== 0);
-    PioneerDDJFLX4.wheelTouch[deckIdx] = touching;
+ PioneerDDJFLX4.jogTouchShift = function(channel, _control, value, _status, group) {
+     const deckIdx = PioneerDDJFLX4._deckIndexFromGroup(group);
+     const deckNum = deckIdx + 1;
 
-    if (touching) {
-        PioneerDDJFLX4._scratchAction[deckIdx] = "seek";
-        PioneerDDJFLX4._scratchEnable(deckNum);
-        return;
-    }
+     // same loop-adjust guard
+     if (PioneerDDJFLX4.loopAdjustIn[deckIdx] || PioneerDDJFLX4.loopAdjustOut[deckIdx]) {
+         return;
+     }
 
-    if (PioneerDDJFLX4._scratchEnabled[deckIdx]) {
-        PioneerDDJFLX4._scratchDisable(deckNum);
-    } else {
-        PioneerDDJFLX4._scratchAction[deckIdx] = "bend";
-    }
-};
+     const touching = (value !== 0);
+     PioneerDDJFLX4.wheelTouch[deckIdx] = touching;
+
+     if (touching) {
+         PioneerDDJFLX4._scratchAction[deckIdx] = "seek";
+         PioneerDDJFLX4._scratchEnable(deckNum);
+         return;
+     }
+
+     if (PioneerDDJFLX4._scratchEnabled[deckIdx]) {
+         PioneerDDJFLX4._scratchDisable(deckNum);
+     } else {
+         PioneerDDJFLX4._scratchAction[deckIdx] = "bend";
+     }
+ };
 
 // ---------- turn handlers ----------
 PioneerDDJFLX4.jogTurn = function(channel, _control, value, _status, group) {

--- a/controllers/Pioneer-DDJ-FLX4-2.0.script.js
+++ b/controllers/Pioneer-DDJ-FLX4-2.0.script.js
@@ -821,6 +821,186 @@ PioneerDDJFLX4.loadShiftPressed = function(_channel, control, value, _status, _g
     }
 };
 
+///////////////////////////////////////////////////////////////
+// PLAY BUTTON: OPTIONAL VINYL BRAKE / SOFT START
+//
+// Configurable behaviour for the PLAY button when Vinyl Mode
+// is active on the deck.
+//
+// Behaviour:
+//
+// PLAY_BRAKE_ON_VINYL = false
+//     -> PLAY behaves like normal Play/Pause
+//
+// PLAY_BRAKE_ON_VINYL = true
+//     -> when Vinyl Mode is active:
+//        stopped deck  -> soft start playback
+//        playing deck  -> apply vinyl brake
+//        press during brake -> cancel brake and resume playback
+//
+// SHIFT+PLAY (reverseroll) is unaffected.
+///////////////////////////////////////////////////////////////
+
+
+// -----------------------------------------------------------------------------
+// USER OPTION
+// -----------------------------------------------------------------------------
+PioneerDDJFLX4.PLAY_BRAKE_ON_VINYL = false;
+
+
+// -----------------------------------------------------------------------------
+// RUNTIME STATE
+// -----------------------------------------------------------------------------
+
+if (!Array.isArray(PioneerDDJFLX4._brakeInProgress)) {
+    PioneerDDJFLX4._brakeInProgress = [false, false];
+}
+
+if (!Array.isArray(PioneerDDJFLX4._brakeCompleted)) {
+    PioneerDDJFLX4._brakeCompleted = [false, false];
+}
+
+if (!Array.isArray(PioneerDDJFLX4._brakeWatchTimer)) {
+    PioneerDDJFLX4._brakeWatchTimer = [-1, -1];
+}
+
+
+// -----------------------------------------------------------------------------
+// CANCEL BRAKE WATCH
+// -----------------------------------------------------------------------------
+
+PioneerDDJFLX4._cancelBrakeWatch = function(deckIdx) {
+
+    const t = PioneerDDJFLX4._brakeWatchTimer[deckIdx];
+
+    if (t !== -1) {
+        try {
+            engine.stopTimer(t);
+        } catch (e) {}
+
+        PioneerDDJFLX4._brakeWatchTimer[deckIdx] = -1;
+    }
+
+    PioneerDDJFLX4._brakeInProgress[deckIdx] = false;
+};
+
+
+// -----------------------------------------------------------------------------
+// STOP VINYL FX
+// -----------------------------------------------------------------------------
+
+PioneerDDJFLX4._stopAllVinylFx = function(deck) {
+
+    try {
+        if (typeof engine.isBrakeActive === "function" && engine.isBrakeActive(deck)) {
+            engine.brake(deck, false);
+        }
+    } catch (e) {}
+
+    try {
+        if (typeof engine.isSoftStartActive === "function" && engine.isSoftStartActive(deck)) {
+            engine.softStart(deck, false);
+        }
+    } catch (e) {}
+};
+
+
+// -----------------------------------------------------------------------------
+// BRAKE WATCH TIMER
+// -----------------------------------------------------------------------------
+
+PioneerDDJFLX4._startBrakeWatch = function(deckIdx, group) {
+
+    const deck = deckIdx + 1;
+
+    PioneerDDJFLX4._cancelBrakeWatch(deckIdx);
+
+    PioneerDDJFLX4._brakeInProgress[deckIdx] = true;
+    PioneerDDJFLX4._brakeCompleted[deckIdx] = false;
+
+    PioneerDDJFLX4._brakeWatchTimer[deckIdx] = engine.beginTimer(50, function() {
+
+        let done = false;
+
+        if (typeof engine.isBrakeActive === "function") {
+            done = !engine.isBrakeActive(deck);
+        } else {
+            done = engine.getValue(group, "play") === 0;
+        }
+
+        if (done) {
+
+            engine.setValue(group, "play", 0);
+
+            PioneerDDJFLX4._cancelBrakeWatch(deckIdx);
+            PioneerDDJFLX4._brakeCompleted[deckIdx] = true;
+        }
+
+    });
+};
+
+
+// -----------------------------------------------------------------------------
+// PLAY BUTTON HANDLER
+// -----------------------------------------------------------------------------
+
+PioneerDDJFLX4.playPressed = function(_channel, _control, value, _status, group) {
+
+    if (value !== 0x7F) return;
+
+    const deckIdx = PioneerDDJFLX4._deckIndexFromGroup(group);
+    const deck = deckIdx + 1;
+
+    const vinylOn = !!PioneerDDJFLX4._vinylWanted[deckIdx];
+    const brakeMode = !!PioneerDDJFLX4.PLAY_BRAKE_ON_VINYL;
+
+    // Normal behaviour if vinyl mode is off or brake mode disabled
+    if (!vinylOn || !brakeMode) {
+        script.toggleControl(group, "play");
+        return;
+    }
+
+    // If brake currently running → cancel brake and resume playback
+    if (PioneerDDJFLX4._brakeInProgress[deckIdx] &&
+        !PioneerDDJFLX4._brakeCompleted[deckIdx]) {
+
+        PioneerDDJFLX4._stopAllVinylFx(deck);
+        PioneerDDJFLX4._cancelBrakeWatch(deckIdx);
+
+        PioneerDDJFLX4._brakeInProgress[deckIdx] = false;
+        PioneerDDJFLX4._brakeCompleted[deckIdx] = false;
+
+        engine.setValue(group, "play", 1);
+        return;
+    }
+
+    // Deck stopped → start playback with soft start
+    if (PioneerDDJFLX4._brakeCompleted[deckIdx] ||
+        engine.getValue(group, "play") === 0) {
+
+        PioneerDDJFLX4._cancelBrakeWatch(deckIdx);
+        PioneerDDJFLX4._brakeCompleted[deckIdx] = false;
+
+        engine.setValue(group, "play", 1);
+
+        if (typeof engine.softStart === "function") {
+            engine.softStart(deck, true);
+        }
+
+        return;
+    }
+
+    // Deck playing → start brake
+    PioneerDDJFLX4._stopAllVinylFx(deck);
+    PioneerDDJFLX4._startBrakeWatch(deckIdx, group);
+
+    if (typeof engine.brake === "function") {
+        engine.brake(deck, true);
+    } else {
+        engine.setValue(group, "play", 0);
+    }
+};
+
 //
 // Effects (Beat FX rework)
 //


### PR DESCRIPTION
This PR resolves issue #1.

Changes:

- optional vinyl brake / soft start behavior for Play button
- controlled via PLAY_BRAKE_ON_VINYL script option (default: false)

Additional improvements:
- documentation split into CONTROLS.md and CONFIGURATION.md
- clearer documentation of mapping behavior

Fixes #1