### PR TITLE
feat(smartfader): slip and keylock gestures on the SMART FADER button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Smart Fader tap and hold gestures for slip, keylock, and key reset
 - Shift-based stem volume control on EQ knobs
   - Shift + LOW controls drums + bass stem volume
   - Shift + MID controls melody / instruments stem volume

--- a/CONTROLS.md
+++ b/CONTROLS.md
@@ -335,6 +335,37 @@ effect.
 
 * Cycle QuickEffect preset
 
+## Smart Fader button
+
+### Tap
+
+* Toggle slip mode on both decks
+
+### Hold
+
+* Enable slip mode on both decks while held
+* Restore each deck's previous slip state on release
+
+### Left Shift + tap
+
+* Toggle keylock on Deck 1
+
+### Right Shift + tap
+
+* Toggle keylock on Deck 2
+
+### Left Shift + hold
+
+* Reset key on Deck 1
+
+### Right Shift + hold
+
+* Reset key on Deck 2
+
+Both Shifts + press is reserved (no action). The Smart Fader button LED is
+never driven: writing its address (0x96 0x01) arms the FLX4's onboard
+smart-fader engine, which moves the mid EQs. Slip state is shown on screen.
+
 ## Filter knobs
 
 * 14-bit control

--- a/controllers/Pioneer-DDJ-FLX4-2.0.midi.xml
+++ b/controllers/Pioneer-DDJ-FLX4-2.0.midi.xml
@@ -1008,6 +1008,27 @@
           <Script-Binding />
         </options>
       </control>
+      <!-- SMART FADER -->
+      <control>
+        <description>SMART FADER - press/release - slip gestures</description>
+        <group>[App]</group>
+        <key>PioneerDDJFLX4.smartFaderPress</key>
+        <status>0x96</status>
+        <midino>0x01</midino>
+        <options>
+          <Script-Binding />
+        </options>
+      </control>
+      <control>
+        <description>SMART FADER +SHIFT - press/release - keylock and key-reset gestures</description>
+        <group>[App]</group>
+        <key>PioneerDDJFLX4.smartFaderPress</key>
+        <status>0x96</status>
+        <midino>0x09</midino>
+        <options>
+          <Script-Binding />
+        </options>
+      </control>
       <!-- BEAT FX SECTION START -->
       <control>
         <description>BEAT FX SELECT - press - cycle Beat FX groups</description>

--- a/controllers/Pioneer-DDJ-FLX4-2.0.script.js
+++ b/controllers/Pioneer-DDJ-FLX4-2.0.script.js
@@ -79,6 +79,10 @@
 // - 14-bit filter knob handling
 // - Optional response shaping around center position
 //
+// Smart Fader
+// - Tap / hold gesture separation with press-time Shift snapshots
+// - Slip, keylock and key-reset shortcuts
+//
 // Looping
 // - Two loop models:
 //     * simple (direct)
@@ -107,7 +111,6 @@
 // Not Implemented
 // -----------------------------------------------------------------------------
 //
-// - Smart Fader
 // - Dedicated Vinyl LED feedback
 // - Backspin inertia simulation
 // - Additional experimental pad layers
@@ -210,6 +213,13 @@ PioneerDDJFLX4.SAMPLER_LONGPRESS_MS = 350;
 // Long press  → toggle keylock
 //
 PioneerDDJFLX4.QUANTIZE_LONGPRESS_MS = 350;
+
+// Time threshold (milliseconds) for SMART FADER button long press.
+//
+// Tap  -> toggle slip / keylock depending on Shift
+// Hold -> momentary slip / reset key depending on Shift
+//
+PioneerDDJFLX4.SMART_FADER_LONGPRESS_MS = 330;
 
 //beatFx
 // Preset order expected:
@@ -376,6 +386,15 @@ PioneerDDJFLX4._beatFxKnob = { msb: 0, lsb: 0 };
 PioneerDDJFLX4._beatFxKnobLast = { msb: -1, lsb: -1 };
 
 PioneerDDJFLX4._smartCfx = { enabled: false };
+
+PioneerDDJFLX4._smartFader = {
+    pressed: false,
+    timer: 0,
+    held: false,
+    shiftDeck1: false,
+    shiftDeck2: false,
+    slipBefore: [0, 0],
+};
 
 PioneerDDJFLX4.wheelTouch = [false, false];
 PioneerDDJFLX4._scratchEnabled = [false, false];
@@ -2393,6 +2412,93 @@ PioneerDDJFLX4.smartCfxPress = function(_ch, control, value, _status, _group) {
     PioneerDDJFLX4.setLed(0x96, 0x00, nextEnabled);
 };
 
+// --- SMART FADER ---
+
+PioneerDDJFLX4._smartFaderHold = function() {
+    const state = PioneerDDJFLX4._smartFader;
+    if (!state.pressed) return;
+
+    state.timer = 0;
+    state.held = true;
+
+    if (state.shiftDeck1 && state.shiftDeck2) {
+        // both shifts held: reserved, no action
+        return;
+    }
+
+    if (state.shiftDeck1) {
+        script.triggerControl("[Channel1]", "reset_key");
+        return;
+    }
+
+    if (state.shiftDeck2) {
+        script.triggerControl("[Channel2]", "reset_key");
+        return;
+    }
+
+    state.slipBefore = [
+        engine.getValue("[Channel1]", "slip_enabled"),
+        engine.getValue("[Channel2]", "slip_enabled"),
+    ];
+    engine.setValue("[Channel1]", "slip_enabled", 1);
+    engine.setValue("[Channel2]", "slip_enabled", 1);
+};
+
+PioneerDDJFLX4.smartFaderPress = function(_channel, _control, value, _status, _group) {
+    const state = PioneerDDJFLX4._smartFader;
+
+    if (value === 0x7F) {
+        if (state.pressed) return;
+
+        state.pressed = true;
+        state.held = false;
+        state.shiftDeck1 = !!PioneerDDJFLX4._shiftDeck1;
+        state.shiftDeck2 = !!PioneerDDJFLX4._shiftDeck2;
+
+        if (state.timer) engine.stopTimer(state.timer);
+        state.timer = engine.beginTimer(
+            PioneerDDJFLX4.SMART_FADER_LONGPRESS_MS,
+            PioneerDDJFLX4._smartFaderHold,
+            true
+        );
+        return;
+    }
+
+    if (value !== 0x00 || !state.pressed) return;
+
+    state.pressed = false;
+    if (state.timer) {
+        engine.stopTimer(state.timer);
+        state.timer = 0;
+    }
+
+    if (state.held) {
+        if (!state.shiftDeck1 && !state.shiftDeck2) {
+            engine.setValue("[Channel1]", "slip_enabled", state.slipBefore[0]);
+            engine.setValue("[Channel2]", "slip_enabled", state.slipBefore[1]);
+        }
+        return;
+    }
+
+    if (state.shiftDeck1 && state.shiftDeck2) return;
+
+    if (state.shiftDeck1) {
+        script.toggleControl("[Channel1]", "keylock");
+        return;
+    }
+
+    if (state.shiftDeck2) {
+        script.toggleControl("[Channel2]", "keylock");
+        return;
+    }
+
+    const slipOn =
+        engine.getValue("[Channel1]", "slip_enabled") > 0 ||
+        engine.getValue("[Channel2]", "slip_enabled") > 0;
+    engine.setValue("[Channel1]", "slip_enabled", slipOn ? 0 : 1);
+    engine.setValue("[Channel2]", "slip_enabled", slipOn ? 0 : 1);
+};
+
 /**
  * Shapes a linear value (0..1) into a symmetric curve around the center (0.5).
  *
@@ -3980,6 +4086,18 @@ PioneerDDJFLX4.shutdown = function() {
     // generated while the remaining runtime state is being torn down.
     stopTimer(PioneerDDJFLX4.keepAliveTimer);
     PioneerDDJFLX4.keepAliveTimer = 0;
+
+    // --- SMART FADER long-press timer and momentary slip ---
+    const smartFader = PioneerDDJFLX4._smartFader;
+    stopTimer(smartFader.timer);
+    if (smartFader.pressed && smartFader.held && !smartFader.shiftDeck1 && !smartFader.shiftDeck2) {
+        deckGroups.forEach(function(group, deckIdx) {
+            engine.setValue(group, "slip_enabled", smartFader.slipBefore[deckIdx]);
+        });
+    }
+    smartFader.timer = 0;
+    smartFader.pressed = false;
+    smartFader.held = false;
 
     // --- Peak latch timers ---
     stopTimer(PioneerDDJFLX4._peakTimerL);


### PR DESCRIPTION
## What

Adds six side-aware gestures to the SMART FADER button, which the mapping previously left unused (it was listed under "Not Implemented"):

| Gesture | Action |
|---|---|
| Tap | Toggle slip mode on both decks |
| Hold | Momentary slip on both decks, previous state restored on release |
| Left Shift + tap | Toggle keylock on Deck 1 |
| Right Shift + tap | Toggle keylock on Deck 2 |
| Left Shift + hold | Reset key on Deck 1 |
| Right Shift + hold | Reset key on Deck 2 |
| Both Shifts + press | Reserved, no action |

## Why

- Slip and keylock are set-critical toggles that otherwise need the mouse mid-performance; SMART FADER is the only face button without a Mixxx duty in this mapping.
- The gestures reuse the existing per-side shift tracking (`_shiftDeck1` / `_shiftDeck2`), so left/right Shift naturally selects deck 1/2.
- Tap vs hold is separated with a 330 ms long-press timer and press-time Shift snapshots, following the existing `SAMPLER_LONGPRESS_MS` / `QUANTIZE_LONGPRESS_MS` pattern (configurable as `SMART_FADER_LONGPRESS_MS`).

## Why the LED is never driven

Writing the SMART FADER LED address (0x96 0x01) arms the FLX4's onboard smart-fader engine, which then emits mid-EQ CCs on its own; the firmware ignores Note-Off (0x86) and any velocity below 0x7F, so the address is a single hardware state bit (verified against the official DDJ-FLX4 MIDI message list). The mapping therefore never writes that address - consistent with the "intentionally disabled" note already in the script. Slip state is visible on screen instead.

## Notes

- Rebased on current `main`; the SMART FADER teardown is integrated into the new structured `shutdown()` (uses the `stopTimer` helper and restores momentary slip state on shutdown).
- `CONTROLS.md` and `CHANGELOG.md` updated accordingly; no other controls are touched.
- Field-tested on hardware (DDJ-FLX4, Mixxx 2.6).